### PR TITLE
fix: locked bonus and use strategy smoothing

### DIFF
--- a/app/api/aprs/[address]/route.ts
+++ b/app/api/aprs/[address]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isAddress } from "viem";
-import { readVaultAprs, getSmoothedApr, enrichComponentsWithSmoothed } from "@/lib/redis";
+import { readVaultAprs } from "@/lib/redis";
 
 export async function GET(
   _request: NextRequest,
@@ -16,7 +16,6 @@ export async function GET(
   }
 
   try {
-    // readVaultAprs lowercases internally, so case-insensitive lookup works
     const [result] = await readVaultAprs([address]);
 
     if (!result) {
@@ -25,13 +24,6 @@ export async function GET(
         { status: 404 },
       );
     }
-
-    const smoothed = await getSmoothedApr(address);
-    if (smoothed && smoothed.samples > 1) {
-      result.apr = smoothed.apr;
-      result.apy = smoothed.apy;
-    }
-    await enrichComponentsWithSmoothed(address, result.components);
 
     return NextResponse.json(result, {
       headers: { "Cache-Control": "s-maxage=900, stale-while-revalidate=60" },

--- a/app/api/aprs/route.ts
+++ b/app/api/aprs/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { readAprResult, getSmoothedApr, enrichComponentsWithSmoothed } from "@/lib/redis";
-import type { VaultAprResult } from "@/lib/models";
+import { readAprResult } from "@/lib/redis";
 
 export async function GET() {
   try {
@@ -10,17 +9,6 @@ export async function GET() {
         { error: "No APR data available. Run sync first." },
         { status: 404 },
       );
-    }
-
-    // Overwrite instant APR/APY with 24h smoothed values when available
-    for (const [address, raw] of Object.entries(data)) {
-      const vault = raw as VaultAprResult;
-      const smoothed = await getSmoothedApr(address);
-      if (smoothed && smoothed.samples > 1) {
-        vault.apr = smoothed.apr;
-        vault.apy = smoothed.apy;
-      }
-      await enrichComponentsWithSmoothed(address, vault.components);
     }
 
     return NextResponse.json(data, {

--- a/app/api/sync/route.ts
+++ b/app/api/sync/route.ts
@@ -3,7 +3,7 @@ import { loadServiceConfig } from "@/lib/config";
 import { initOnchainClients } from "@/lib/onchain";
 import { syncAll } from "@/lib/strategy-store";
 import { computeAllVaultsApr } from "@/lib/apr-service";
-import { writeAprResult, clearCache, pushAprSnapshot } from "@/lib/redis";
+import { writeAprResult, clearCache } from "@/lib/redis";
 
 export const maxDuration = 120;
 
@@ -39,14 +39,6 @@ async function sync(reset: boolean = false) {
 
   const aprResults = await computeAllVaultsApr(config.apr);
   await writeAprResult(aprResults as unknown as Record<string, unknown>);
-
-  // Push APR snapshots for rolling average (vault + per-strategy)
-  for (const [address, vault] of Object.entries(aprResults)) {
-    await pushAprSnapshot(address, vault.apr, vault.apy);
-    for (const component of vault.components) {
-      await pushAprSnapshot(`${address}:${component.label}`, component.apr, component.apy);
-    }
-  }
 
   return { ok: true, vaults: summary, apr: aprResults };
 }

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -1,10 +1,6 @@
 import { aprToApy, unlockTimeToPeriodsPerYear } from "@/lib/apy";
 import { getVaultProfitMaxUnlockTime, ONE } from "@/lib/onchain";
-import {
-  enrichComponentsWithSmoothed,
-  getSmoothedApr,
-  readVaultAprs,
-} from "@/lib/redis";
+import { readVaultAprs } from "@/lib/redis";
 import {
   findComponent,
   jsonResponseWithBigInt,
@@ -14,8 +10,8 @@ import {
 } from "@/lib/webhook-utils";
 import { NextRequest, NextResponse } from "next/server";
 
-const YVUSD_ADDRESS = process.env.YVUSD_ADDRESS ?? "";
-const LOCKED_YVUSD_ADDRESS = process.env.LOCKED_YVUSD_ADDRESS ?? "";
+const YVUSD_ADDRESS = "0x696d02Db93291651ED510704c9b286841d506987";
+const LOCKED_YVUSD_ADDRESS = "0xAaaFEa48472f77563961Cdb53291DEDfB46F9040";
 
 export async function OPTIONS() {
   return new Response("", {});
@@ -44,8 +40,8 @@ export async function POST(request: NextRequest) {
   try {
     const { addresses, blockNumber, blockTime, label } =
       parseWebhookBody(rawBody);
-    const yvusd = YVUSD_ADDRESS.toLowerCase();
-    const locked = LOCKED_YVUSD_ADDRESS.toLowerCase();
+    const yvusd = (process.env.YVUSD_ADDRESS ?? YVUSD_ADDRESS).toLowerCase();
+    const locked = (process.env.LOCKED_YVUSD_ADDRESS ?? LOCKED_YVUSD_ADDRESS).toLowerCase();
 
     const filteredAddresses = addresses.filter(
       (a) => a.toLowerCase() === yvusd || a.toLowerCase() === locked,
@@ -57,17 +53,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const requestedAddresses = new Set(filteredAddresses.map((address) => address.toLowerCase()));
     const aprResults = await readVaultAprs(filteredAddresses);
     const outputs: KongOutput[] = [];
 
     for (const vault of aprResults) {
       if (!vault) continue;
-      const smoothed = await getSmoothedApr(vault.address);
-      if (smoothed && smoothed.samples > 1) {
-        vault.apr = smoothed.apr;
-        vault.apy = smoothed.apy;
-      }
-      await enrichComponentsWithSmoothed(vault.address, vault.components);
+      if (!requestedAddresses.has(vault.address.toLowerCase())) continue;
       const base = {
         chainId: vault.chain_id,
         address: vault.address,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import { headers } from "next/headers";
-import { readAprResult, getSmoothedApr, enrichComponentsWithSmoothed } from "@/lib/redis";
+import { readAprResult } from "@/lib/redis";
 import type { VaultAprResult } from "@/lib/models";
 import { CopyButton } from "./copy-button";
 
@@ -42,39 +42,22 @@ async function fetchKongVaults(): Promise<VaultAprResult[]> {
   return results;
 }
 
-async function fetchSmoothedVaults(): Promise<VaultAprResult[]> {
-  const data = await readAprResult();
-  if (!data) return [];
-  for (const [address, raw] of Object.entries(data)) {
-    const vault = raw as VaultAprResult;
-    const smoothed = await getSmoothedApr(address);
-    if (smoothed && smoothed.samples > 1) {
-      vault.apr = smoothed.apr;
-      vault.apy = smoothed.apy;
-    }
-    await enrichComponentsWithSmoothed(address, vault.components);
-  }
-  return Object.values(data) as VaultAprResult[];
-}
-
 async function fetchRawVaults(): Promise<VaultAprResult[]> {
   const data = await readAprResult();
   if (!data) return [];
   return Object.values(data) as VaultAprResult[];
 }
 
-type Format = "kong" | "smooth" | "raw";
+type Format = "kong" | "raw";
 
 export default async function Home({ searchParams }: { searchParams: Promise<{ format?: string }> }) {
   const params = await searchParams;
-  const format = (["kong", "smooth", "raw"].includes(params.format ?? "") ? params.format : "kong") as Format;
+  const format = (["kong", "raw"].includes(params.format ?? "") ? params.format : "kong") as Format;
 
   let vaults: VaultAprResult[] = [];
   try {
     if (format === "kong") {
       vaults = await fetchKongVaults();
-    } else if (format === "smooth") {
-      vaults = await fetchSmoothedVaults();
     } else {
       vaults = await fetchRawVaults();
     }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -58,7 +58,7 @@ apr:
       '0x41CA7586cC1311807B4605fBB748a3B8862b42b5':
         type: oracle-growth
         oracle: '0x8f30fF3d54e69D4dfD5E99a9937474FaDdf27009'
-        window_seconds: 259200
+        window_seconds: 172800
         fallback_apr: 0.04
     strategies:
       '0x5f9dba2805411a8382fdb4e69d4f2da8efaf1f89':

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -58,7 +58,7 @@ apr:
       '0x41CA7586cC1311807B4605fBB748a3B8862b42b5':
         type: oracle-growth
         oracle: '0x8f30fF3d54e69D4dfD5E99a9937474FaDdf27009'
-        window_seconds: 604800
+        window_seconds: 259200
         fallback_apr: 0.04
     strategies:
       '0x5f9dba2805411a8382fdb4e69d4f2da8efaf1f89':

--- a/lib/apr-engine.ts
+++ b/lib/apr-engine.ts
@@ -12,9 +12,15 @@ import {
   getStrategyLeverageRatio,
   getStrategyPendleMarket,
   getStrategyPendleRouter,
+  getPendlePtRealizedApy,
   getPendleMarketImpliedApy,
   getPendleMarketApyFromApi,
+  getAaveReserveCurrentBorrowApy,
+  getAaveReserveCurrentSupplyApy,
+  getAaveReserveHistoricalBorrowApy,
+  getAaveReserveHistoricalSupplyApy,
   getMorphoMarketBorrowApy,
+  getMorphoMarketHistoricalBorrowApy,
   fetchVaultAprData,
 } from "./onchain";
 import {
@@ -37,7 +43,15 @@ const OFFCHAIN_TYPES = new Set([
 ]);
 
 const MORPHO_LOOPER_TYPES = new Set(["morpho", "morpho-looper"]);
-const MORPHO_STRATEGY_TYPES = new Set(["morpho-looper", "pt-morpho-looper"]);
+const LOOPER_STRATEGY_TYPES = new Set([
+  "looper",
+  "morpho-looper",
+  "aave-looper",
+  "pt-looper",
+  "pt-morpho-looper",
+  "pt-aave-looper",
+]);
+const AAVE_STRATEGY_TYPES = new Set(["aave-looper", "pt-aave-looper"]);
 const DEFAULT_HISTORICAL_WINDOW_SECONDS = 7 * 24 * 60 * 60;
 const CHAIN_MORPHO_ADDRESSES: Record<number, string> = {
   1: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
@@ -356,8 +370,8 @@ export class YvUsdAprEngine {
     let mode = String(cfg.type ?? "").trim().toLowerCase().replace(/_/g, "-");
     const strategyType = String(entry.meta.type ?? "").trim().toLowerCase().replace(/_/g, "-");
 
-    if (!mode && MORPHO_STRATEGY_TYPES.has(strategyType)) {
-      mode = "morpho-looper";
+    if (!mode && LOOPER_STRATEGY_TYPES.has(strategyType)) {
+      mode = strategyType;
     }
     if (!mode && strategyType === "pt") {
       mode = "pt-estimated";
@@ -377,8 +391,8 @@ export class YvUsdAprEngine {
       return this._getPtEstimatedOffchainApr(entry, chainId, cfg);
     }
 
-    if (MORPHO_LOOPER_TYPES.has(mode)) {
-      return this._getMorphoLooperOffchainApr(entry, chainId, cfg);
+    if (mode === "looper" || LOOPER_STRATEGY_TYPES.has(mode) || MORPHO_LOOPER_TYPES.has(mode)) {
+      return this._getLooperOffchainApr(entry, chainId, cfg);
     }
 
     return null;
@@ -391,15 +405,7 @@ export class YvUsdAprEngine {
   ): Promise<bigint | null> {
     const ptToken = String(cfg.pt ?? cfg.pt_token ?? entry.meta.pt ?? "").trim();
     let apiApyRaw: bigint | null = null;
-
-    let pendleRouter = String(cfg.pendle_router ?? entry.meta.pendle_router ?? "").trim();
-    if (!pendleRouter) {
-      pendleRouter = (await getStrategyPendleRouter(entry.address, chainId)) ?? "";
-    }
-    if (!pendleRouter && ptToken) {
-      pendleRouter = (await getStrategyPendleRouter(ptToken, chainId)) ?? "";
-    }
-    if (!pendleRouter) return null;
+    const windowSeconds = this._resolveWindowSeconds(cfg);
 
     let pendleMarket = String(cfg.market ?? entry.meta.market ?? "").trim();
     if (!pendleMarket) {
@@ -419,12 +425,37 @@ export class YvUsdAprEngine {
       }
     }
 
+    if (pendleMarket) {
+      const realizedApy = await getPendlePtRealizedApy(
+        pendleMarket,
+        chainId,
+        windowSeconds,
+      );
+      if (realizedApy !== null) return realizedApy;
+    }
+
+    let pendleRouter = String(cfg.pendle_router ?? entry.meta.pendle_router ?? "").trim();
+    if (!pendleRouter) {
+      pendleRouter = (await getStrategyPendleRouter(entry.address, chainId)) ?? "";
+    }
+    if (!pendleRouter && ptToken) {
+      pendleRouter = (await getStrategyPendleRouter(ptToken, chainId)) ?? "";
+    }
+
     if (pendleMarket && pendleRouter) {
       const onchainApy = await getPendleMarketImpliedApy(pendleMarket, pendleRouter, chainId);
       if (onchainApy !== null) return onchainApy;
     }
 
     return apiApyRaw;
+  }
+
+  private _resolveWindowSeconds(cfg: Record<string, unknown>): number {
+    let windowSeconds = parseIntValue(cfg.window_seconds);
+    if (windowSeconds === null || windowSeconds <= 0n) {
+      windowSeconds = BigInt(DEFAULT_HISTORICAL_WINDOW_SECONDS);
+    }
+    return Number(windowSeconds);
   }
 
   private async _getHistoricalOffchainApr(
@@ -435,17 +466,14 @@ export class YvUsdAprEngine {
     const address = String(cfg.address ?? entry.address ?? "").trim();
     if (!address) return null;
 
-    let windowSeconds = parseIntValue(cfg.window_seconds);
-    if (windowSeconds === null || windowSeconds <= 0n) {
-      windowSeconds = BigInt(DEFAULT_HISTORICAL_WINDOW_SECONDS);
-    }
+    const windowSeconds = this._resolveWindowSeconds(cfg);
 
     let sharesRaw = parseIntValue(cfg.shares_raw);
     if (sharesRaw === null || sharesRaw <= 0n) {
       sharesRaw = ONE;
     }
 
-    return getHistoricalConvertToAssetsApr(address, chainId, Number(windowSeconds), sharesRaw);
+    return getHistoricalConvertToAssetsApr(address, chainId, windowSeconds, sharesRaw);
   }
 
   private async _getOracleGrowthOffchainApr(
@@ -456,32 +484,31 @@ export class YvUsdAprEngine {
     const oracleAddress = String(cfg.oracle ?? "").trim();
     if (!oracleAddress) return null;
 
-    let windowSeconds = parseIntValue(cfg.window_seconds);
-    if (windowSeconds === null || windowSeconds <= 0n) {
-      windowSeconds = BigInt(DEFAULT_HISTORICAL_WINDOW_SECONDS);
-    }
+    const windowSeconds = this._resolveWindowSeconds(cfg);
 
-    const apr = await getOracleGrowthApr(oracleAddress, chainId, Number(windowSeconds));
+    const apr = await getOracleGrowthApr(oracleAddress, chainId, windowSeconds);
     if (apr !== null) return apr;
 
     // Fallback to static APR if provided and no history yet
     return parseAprValue(cfg, "fallback_apr_raw", "fallback_apr");
   }
 
-  private async _getMorphoLooperOffchainApr(
+  private async _getLooperOffchainApr(
     entry: StrategyEntry,
     chainId: number,
     cfg: Record<string, unknown>,
   ): Promise<bigint | null> {
+    const windowSeconds = this._resolveWindowSeconds(cfg);
+
     let collateralApr = parseAprValue(cfg, "collateral_apr_raw", "collateral_apr");
     if (collateralApr === null) {
-      collateralApr = await this._getCollateralVaultApr(entry, chainId);
+      collateralApr = await this._getCollateralAssetApr(entry, chainId, windowSeconds);
     }
     if (collateralApr === null) return null;
 
     let borrowApy = parseAprValue(cfg, "borrow_apy_raw", "borrow_apy");
     if (borrowApy === null) {
-      borrowApy = await this._getMorphoBorrowApy(entry, chainId, cfg);
+      borrowApy = await this._getLooperBorrowApy(entry, chainId, cfg, windowSeconds);
     }
     if (borrowApy === null) return null;
 
@@ -496,55 +523,138 @@ export class YvUsdAprEngine {
     return supplyComponent - borrowComponent;
   }
 
-  private async _getCollateralVaultApr(
+  private async _getCollateralAssetApr(
     entry: StrategyEntry,
     chainId: number,
+    windowSeconds: number,
   ): Promise<bigint | null> {
     const meta = entry.meta ?? {};
+    const strategyType = String(meta.type ?? "").trim().toLowerCase().replace(/_/g, "-");
     const collateral = meta.collateral as { address?: string } | undefined;
     if (!collateral || typeof collateral !== "object") return null;
 
-    const collateralVault = String(collateral.address ?? "").trim();
-    if (!collateralVault) return null;
+    const collateralAddress = String(collateral.address ?? "").trim();
+    if (!collateralAddress) return null;
 
-    const hardcoded = await this._getAddressOverrideApr(collateralVault, chainId);
-    if (hardcoded !== null) return hardcoded;
+    const overridden = await this._getAddressOverrideApr(collateralAddress, chainId, windowSeconds);
+    if (overridden !== null) return overridden;
 
-    const [, netApr] = await this.getCustomExpectedApr(collateralVault, null, chainId, 0);
+    if (strategyType.startsWith("pt")) {
+      const collateralMarket = String(meta.market ?? "").trim();
+      const collateralRouter = String(meta.pendle_router ?? "").trim();
+      const syntheticPtEntry: StrategyEntry = {
+        address: collateralAddress,
+        active: true,
+        apr_source: "offchain",
+        offchain: {
+          type: "pt-estimated",
+          window_seconds: windowSeconds,
+          pt: collateralAddress,
+          ...(collateralMarket ? { market: collateralMarket } : {}),
+          ...(collateralRouter ? { pendle_router: collateralRouter } : {}),
+        },
+        meta: {
+          type: "pt",
+          pt: collateralAddress,
+          ...(collateralMarket ? { market: collateralMarket } : {}),
+          ...(collateralRouter ? { pendle_router: collateralRouter } : {}),
+        },
+        points: false,
+      };
+      const ptApr = await this._getPtEstimatedOffchainApr(
+        syntheticPtEntry,
+        chainId,
+        syntheticPtEntry.offchain,
+      );
+      if (ptApr !== null) return ptApr;
+    }
+
+    const aaveSupplyApy = await getAaveReserveHistoricalSupplyApy(
+      collateralAddress,
+      chainId,
+      windowSeconds,
+    );
+    if (aaveSupplyApy !== null) return aaveSupplyApy;
+
+    const aaveSpotSupplyApy = await getAaveReserveCurrentSupplyApy(collateralAddress, chainId);
+    if (aaveSpotSupplyApy !== null) return aaveSpotSupplyApy;
+
+    const historicalApr = await getHistoricalConvertToAssetsApr(
+      collateralAddress,
+      chainId,
+      windowSeconds,
+      ONE,
+    );
+    if (historicalApr !== null) return historicalApr;
+
+    const [, netApr] = await this.getCustomExpectedApr(collateralAddress, null, chainId, 0);
     return netApr;
   }
 
   private async _getAddressOverrideApr(
     address: string,
     chainId: number,
+    windowSeconds?: number,
   ): Promise<bigint | null> {
     const cfg = getStrategyConfig(address, this._cacheConfig);
     if (cfg.apr_source !== "offchain" || !cfg.offchain || !Object.keys(cfg.offchain).length) {
       return null;
     }
 
-    const mode = String((cfg.offchain as Record<string, unknown>).type ?? "")
+    const offchain = { ...(cfg.offchain as Record<string, unknown>) };
+    const mode = String(offchain.type ?? "")
       .trim()
       .toLowerCase()
       .replace(/_/g, "-");
-    if (MORPHO_LOOPER_TYPES.has(mode)) return null;
+    if (mode === "looper" || LOOPER_STRATEGY_TYPES.has(mode) || MORPHO_LOOPER_TYPES.has(mode)) {
+      return null;
+    }
+
+    if (
+      windowSeconds !== undefined &&
+      windowSeconds > 0 &&
+      offchain.window_seconds === undefined &&
+      (mode === "historical" || mode === "oracle-growth" || mode === "pt" || mode === "pt-estimated")
+    ) {
+      offchain.window_seconds = windowSeconds;
+    }
 
     const syntheticEntry: StrategyEntry = {
       address,
       active: true,
       apr_source: "offchain",
-      offchain: { ...cfg.offchain },
+      offchain,
       meta: { ...(cfg.meta ?? {}) },
       points: Boolean(cfg.points),
     };
     return this._getOffchainStrategyApr(syntheticEntry, chainId);
   }
 
-  private async _getMorphoBorrowApy(
+  private async _getLooperBorrowApy(
     entry: StrategyEntry,
     chainId: number,
     cfg: Record<string, unknown>,
+    windowSeconds: number,
   ): Promise<bigint | null> {
+    const strategyType = String(entry.meta.type ?? "").trim().toLowerCase().replace(/_/g, "-");
+    const aToken = String(
+      cfg.a_token ?? cfg.atoken ?? cfg.aToken ?? entry.meta.aToken ?? "",
+    ).trim();
+
+    if (AAVE_STRATEGY_TYPES.has(strategyType) || aToken) {
+      if (aToken) {
+        const historicalBorrow = await getAaveReserveHistoricalBorrowApy(
+          aToken,
+          chainId,
+          windowSeconds,
+        );
+        if (historicalBorrow !== null) return historicalBorrow;
+
+        return getAaveReserveCurrentBorrowApy(aToken, chainId);
+      }
+      return null;
+    }
+
     let marketId = String(cfg.market_id ?? entry.meta.market_id ?? "").trim();
     let morpho = String(cfg.morpho ?? entry.meta.morpho ?? "").trim();
 
@@ -558,6 +668,14 @@ export class YvUsdAprEngine {
       morpho = CHAIN_MORPHO_ADDRESSES[chainId] ?? "";
     }
     if (!marketId || !morpho) return null;
+
+    const historicalBorrow = await getMorphoMarketHistoricalBorrowApy(
+      morpho,
+      marketId,
+      chainId,
+      windowSeconds,
+    );
+    if (historicalBorrow !== null) return historicalBorrow;
 
     return getMorphoMarketBorrowApy(morpho, marketId, chainId);
   }

--- a/lib/apr-engine.ts
+++ b/lib/apr-engine.ts
@@ -52,7 +52,7 @@ const LOOPER_STRATEGY_TYPES = new Set([
   "pt-aave-looper",
 ]);
 const AAVE_STRATEGY_TYPES = new Set(["aave-looper", "pt-aave-looper"]);
-const DEFAULT_HISTORICAL_WINDOW_SECONDS = 7 * 24 * 60 * 60;
+const DEFAULT_HISTORICAL_WINDOW_SECONDS = 3 * 24 * 60 * 60;
 const CHAIN_MORPHO_ADDRESSES: Record<number, string> = {
   1: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
   137: "0x1bF0c2541F820E775182832f06c0B7Fc27A25f67",

--- a/lib/apr-engine.ts
+++ b/lib/apr-engine.ts
@@ -1,4 +1,7 @@
-import type { StrategyCacheConfig } from "./config";
+import {
+  DEFAULT_HISTORICAL_WINDOW_SECONDS,
+  type StrategyCacheConfig,
+} from "./config";
 import { getAddress } from "viem";
 import {
   ONE,
@@ -52,7 +55,6 @@ const LOOPER_STRATEGY_TYPES = new Set([
   "pt-aave-looper",
 ]);
 const AAVE_STRATEGY_TYPES = new Set(["aave-looper", "pt-aave-looper"]);
-const DEFAULT_HISTORICAL_WINDOW_SECONDS = 3 * 24 * 60 * 60;
 const CHAIN_MORPHO_ADDRESSES: Record<number, string> = {
   1: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
   137: "0x1bF0c2541F820E775182832f06c0B7Fc27A25f67",

--- a/lib/apr-service.ts
+++ b/lib/apr-service.ts
@@ -11,7 +11,7 @@ import { YvUsdAprEngine } from "./apr-engine";
 import { getCalculator } from "./calculators";
 import { aprToApy, unlockTimeToPeriodsPerYear } from "./apy";
 
-const LOCKED_YVUSD_ADDRESS = "0xaaafea48472f77563961cdb53291dedfb46f9040";
+const LOCKED_YVUSD_ADDRESS = "0xAaaFEa48472f77563961Cdb53291DEDfB46F9040";
 
 export async function computeAllVaultsApr(
   config: AprConfig,
@@ -23,7 +23,7 @@ export async function computeAllVaultsApr(
   const results: Record<string, VaultAprResult> = {};
 
   for (const vault of config.vaults) {
-    const isLockedYvUsd = vault.address.toLowerCase() === LOCKED_YVUSD_ADDRESS;
+    const isLockedYvUsd = vault.address.toLowerCase() === LOCKED_YVUSD_ADDRESS.toLowerCase();
     const components = [];
 
     for (const strat of vault.strategies) {

--- a/lib/calculators.ts
+++ b/lib/calculators.ts
@@ -1,5 +1,6 @@
 import type { VaultConfig, StrategyConfig } from "./config";
 import type { AprComponent } from "./models";
+import type { FeeConfig } from "./apr-engine";
 import { YvUsdAprEngine, aprToFloat } from "./apr-engine";
 import { getErc4626Asset } from "./onchain";
 
@@ -9,25 +10,15 @@ type CalculatorFn = (
   engine: YvUsdAprEngine,
 ) => Promise<AprComponent[]>;
 
-async function calculateYvusdBase(
-  vault: VaultConfig,
-  strategy: StrategyConfig,
-  engine: YvUsdAprEngine,
-): Promise<AprComponent[]> {
-  const lockedVault = String(strategy.params?.locked_vault ?? "") || null;
-  const delta = Number(strategy.params?.delta ?? 0) || 0;
-
-  const [grossApr, netApr, feeConfig, strategyMeta] = await engine.getCustomExpectedApr(
-    vault.address,
-    lockedVault,
-    vault.chain_id,
-    delta,
-  );
-
-  if (netApr === null) return [];
-
+function buildAprMeta(
+  strategyId: string,
+  grossApr: bigint | null,
+  netApr: bigint,
+  feeConfig: FeeConfig | null,
+  strategyMeta: Record<string, unknown>[],
+): Record<string, unknown> {
   const meta: Record<string, unknown> = {
-    strategy_id: strategy.id,
+    strategy_id: strategyId,
     apr_decimals: 18,
     gross_apr_raw: String(grossApr ?? 0n),
     net_apr_raw: String(netApr),
@@ -38,16 +29,55 @@ async function calculateYvusdBase(
     meta.performance_fee_bps = feeConfig.performanceFee;
     meta.locker_bonus_bps = feeConfig.lockerBonus;
   }
+  return meta;
+}
 
-  return [
-    {
-      label: "net_apr",
-      apr: aprToFloat(netApr),
-      apy: 0,
-      source: "onchain",
-      meta,
-    },
-  ];
+async function buildHeadlineNetAprComponent(
+  strategyId: string,
+  label: string,
+  vaultAddress: string,
+  lockedVaultAddress: string | null,
+  chainId: number,
+  delta: number,
+  engine: YvUsdAprEngine,
+): Promise<AprComponent | null> {
+  const [grossApr, netApr, feeConfig, strategyMeta] = await engine.getCustomExpectedApr(
+    vaultAddress,
+    lockedVaultAddress,
+    chainId,
+    delta,
+  );
+
+  if (netApr === null) return null;
+
+  return {
+    label,
+    apr: aprToFloat(netApr),
+    apy: 0,
+    source: "onchain",
+    meta: buildAprMeta(strategyId, grossApr, netApr, feeConfig, strategyMeta),
+  };
+}
+
+async function calculateYvusdBase(
+  vault: VaultConfig,
+  strategy: StrategyConfig,
+  engine: YvUsdAprEngine,
+): Promise<AprComponent[]> {
+  const lockedVault = String(strategy.params?.locked_vault ?? "") || null;
+  const delta = Number(strategy.params?.delta ?? 0) || 0;
+
+  const component = await buildHeadlineNetAprComponent(
+    strategy.id,
+    "net_apr",
+    vault.address,
+    lockedVault,
+    vault.chain_id,
+    delta,
+    engine,
+  );
+
+  return component ? [component] : [];
 }
 
 async function calculateLockedYvusd(
@@ -63,11 +93,14 @@ async function calculateLockedYvusd(
   }
   if (!baseVault) return [];
 
-  const [grossApr, netApr, feeConfig, strategyMeta] = await engine.getCustomExpectedApr(
+  const baseNetApr = await buildHeadlineNetAprComponent(
+    strategy.id,
+    "base_net_apr",
     baseVault,
     vault.address,
     vault.chain_id,
-    0,
+    delta,
+    engine,
   );
   const bonusApr = await engine.getLockedExpectedApr(
     baseVault,
@@ -76,36 +109,33 @@ async function calculateLockedYvusd(
     delta,
   );
 
-  const meta: Record<string, unknown> = {
+  const bonusMeta: Record<string, unknown> = {
     strategy_id: strategy.id,
     apr_decimals: 18,
-    gross_apr_raw: String(grossApr ?? 0n),
-    net_apr_raw: String(netApr ?? 0n),
     bonus_apr_raw: String(bonusApr ?? 0n),
-    strategies: strategyMeta,
   };
-  if (feeConfig) {
-    meta.management_fee_bps = feeConfig.managementFee;
-    meta.performance_fee_bps = feeConfig.performanceFee;
-    meta.locker_bonus_bps = feeConfig.lockerBonus;
+  if (baseNetApr?.meta) {
+    for (const key of [
+      "gross_apr_raw",
+      "net_apr_raw",
+      "management_fee_bps",
+      "performance_fee_bps",
+      "locker_bonus_bps",
+    ]) {
+      if (key in baseNetApr.meta) {
+        bonusMeta[key] = baseNetApr.meta[key];
+      }
+    }
   }
 
   const components: AprComponent[] = [];
-  if (netApr !== null) {
-    components.push({
-      label: "base_net_apr",
-      apr: aprToFloat(netApr),
-      apy: 0,
-      source: "onchain",
-      meta,
-    });
-  }
+  if (baseNetApr) components.push(baseNetApr);
   components.push({
     label: "locker_bonus_apr",
     apr: aprToFloat(bonusApr),
     apy: 0,
     source: "onchain",
-    meta,
+    meta: bonusMeta,
   });
   return components;
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -2,6 +2,8 @@ import fs from "fs";
 import path from "path";
 import YAML from "yaml";
 
+export const DEFAULT_HISTORICAL_WINDOW_SECONDS = 3 * 24 * 60 * 60;
+
 export interface SourceRef {
   kind: "onchain" | "offchain";
   name: string;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import YAML from "yaml";
 
-export const DEFAULT_HISTORICAL_WINDOW_SECONDS = 3 * 24 * 60 * 60;
+export const DEFAULT_HISTORICAL_WINDOW_SECONDS = 2 * 24 * 60 * 60;
 
 export interface SourceRef {
   kind: "onchain" | "offchain";

--- a/lib/onchain.ts
+++ b/lib/onchain.ts
@@ -10,6 +10,7 @@ import { mainnet, arbitrum, type Chain } from "viem/chains";
 import type { OnchainSourceConfig, ChainSourceConfig } from "./config";
 
 export const ONE = 10n ** 18n;
+export const RAY = 10n ** 27n;
 export const SECONDS_PER_YEAR = 31_536_000;
 
 const chainDefs: Record<number, Chain> = {
@@ -70,8 +71,20 @@ const targetLeverageAbi = parseAbi([
 ]);
 const morphoAbi = parseAbi(["function morpho() view returns (address)"]);
 const aTokenAbi = parseAbi(["function aToken() view returns (address)"]);
+const aaveReceiptTokenAbi = parseAbi([
+  "function POOL() view returns (address)",
+  "function UNDERLYING_ASSET_ADDRESS() view returns (address)",
+]);
+const aavePoolAbi = parseAbi([
+  "function getReserveNormalizedIncome(address asset) view returns (uint256)",
+  "function getReserveNormalizedVariableDebt(address asset) view returns (uint256)",
+  "function getReserveData(address asset) view returns ((uint256), uint128, uint128, uint128, uint128, uint128, uint40, uint16, address, address, address, address, uint128, uint128, uint128)",
+]);
 const pendleRouterAbi = parseAbi([
   "function pendleRouter() view returns (address)",
+]);
+const pendleRouterStaticAbi = parseAbi([
+  "function getPtToAssetRate(address market) view returns (uint256)",
 ]);
 const routerAbi = parseAbi([
   "function router() view returns (address)",
@@ -112,6 +125,10 @@ const collateralTokenAbi = parseAbi([
 
 const PENDLE_API_BASE_URL = "https://api-v2.pendle.finance/core/v1";
 const PENDLE_API_CACHE_TTL_MS = 60_000;
+const CHAIN_PENDLE_ROUTER_STATIC_ADDRESSES: Record<number, string> = {
+  1: "0x263833d47eA3fA4a30f269323aba6a107f9eB14C",
+  42161: "0xAdB09F65bd90d19e3148D9ccb693F3161C6DB3E8",
+};
 const pendleApiCache = new Map<
   string,
   {
@@ -218,6 +235,48 @@ function isValidNonZeroBytes32(value: string | null): value is `0x${string}` {
   if (!value) return false;
   if (!/^0x[0-9a-fA-F]{64}$/.test(value)) return false;
   return value !== `0x${"0".repeat(64)}`;
+}
+
+function annualizeGrowthRatio(growthRatio: number, elapsedSeconds: number): bigint | null {
+  if (!Number.isFinite(growthRatio) || growthRatio <= 0 || elapsedSeconds <= 0) return null;
+  try {
+    const apy = Math.pow(growthRatio, SECONDS_PER_YEAR / elapsedSeconds) - 1.0;
+    if (!Number.isFinite(apy)) return null;
+    return BigInt(Math.round(apy * Number(ONE)));
+  } catch {
+    return null;
+  }
+}
+
+function annualizeRawGrowth(
+  currentValue: bigint,
+  oldValue: bigint,
+  elapsedSeconds: number,
+): bigint | null {
+  if (currentValue <= 0n || oldValue <= 0n) return null;
+  try {
+    return annualizeGrowthRatio(
+      Number(currentValue) / Number(oldValue),
+      elapsedSeconds,
+    );
+  } catch {
+    return null;
+  }
+}
+
+function rayAnnualRateToApyRaw(rateRay: bigint): bigint {
+  if (rateRay <= 0n) return 0n;
+
+  const linearAprRaw = rateRay / (RAY / ONE);
+  try {
+    const apr = Number(rateRay) / Number(RAY);
+    const apy = Math.expm1(Math.log1p(apr / SECONDS_PER_YEAR) * SECONDS_PER_YEAR);
+    if (!Number.isFinite(apy)) return linearAprRaw > 0n ? linearAprRaw : 0n;
+    const result = BigInt(Math.round(apy * Number(ONE)));
+    return result > 0n ? result : 0n;
+  } catch {
+    return linearAprRaw > 0n ? linearAprRaw : 0n;
+  }
 }
 
 async function probePendleMarket(
@@ -686,6 +745,42 @@ export async function getStrategyPendleRouter(
   return router ?? null;
 }
 
+async function getPendleRouterStatic(chainId: number): Promise<string | null> {
+  const address = CHAIN_PENDLE_ROUTER_STATIC_ADDRESSES[chainId];
+  if (!address) return null;
+  try {
+    return getAddress(address);
+  } catch {
+    return null;
+  }
+}
+
+async function getAaveReserveContext(
+  aToken: string,
+  chainId: number,
+): Promise<{ pool: string; asset: string } | null> {
+  const client = getViemClient(chainId);
+  if (!client) return null;
+
+  try {
+    const [pool, asset] = await Promise.all([
+      client.readContract({
+        address: getAddress(aToken),
+        abi: aaveReceiptTokenAbi,
+        functionName: "POOL",
+      }),
+      client.readContract({
+        address: getAddress(aToken),
+        abi: aaveReceiptTokenAbi,
+        functionName: "UNDERLYING_ASSET_ADDRESS",
+      }),
+    ]);
+    return { pool: getAddress(pool), asset: getAddress(asset) };
+  } catch {
+    return null;
+  }
+}
+
 export async function getPendleMarketApyFromApi(
   chainId: number,
   ptAddress: string,
@@ -823,6 +918,49 @@ export async function getPendleMarketImpliedApy(
   }
 }
 
+async function getPendlePtToAssetRate(
+  market: string,
+  chainId: number,
+  blockNumber?: bigint,
+): Promise<bigint | null> {
+  const client = getViemClient(chainId);
+  if (!client) return null;
+
+  const routerStatic = await getPendleRouterStatic(chainId);
+  if (!routerStatic) return null;
+
+  try {
+    return await client.readContract({
+      address: getAddress(routerStatic),
+      abi: pendleRouterStaticAbi,
+      functionName: "getPtToAssetRate",
+      args: [getAddress(market)],
+      ...(blockNumber !== undefined ? { blockNumber } : {}),
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function getPendlePtRealizedApy(
+  market: string,
+  chainId: number,
+  windowSeconds: number,
+): Promise<bigint | null> {
+  if (windowSeconds <= 0) return null;
+
+  const bounds = await getHistoricalWindowBounds(chainId, windowSeconds);
+  if (!bounds) return null;
+
+  const [currentRate, oldRate] = await Promise.all([
+    getPendlePtToAssetRate(market, chainId, bounds.latestBlockNumber),
+    getPendlePtToAssetRate(market, chainId, bounds.oldBlockNumber),
+  ]);
+  if (currentRate === null || oldRate === null) return null;
+
+  return annualizeRawGrowth(currentRate, oldRate, bounds.elapsedSeconds);
+}
+
 export async function getMorphoMarketBorrowApy(
   morpho: string,
   marketId: string,
@@ -872,6 +1010,178 @@ export async function getMorphoMarketBorrowApy(
     });
 
     return ratePerSecondToApyRaw(borrowRatePerSecond);
+  } catch {
+    return null;
+  }
+}
+
+async function getMorphoMarketBorrowIndex(
+  morpho: string,
+  marketId: string,
+  chainId: number,
+  blockNumber?: bigint,
+): Promise<bigint | null> {
+  const client = getViemClient(chainId);
+  if (!client) return null;
+
+  try {
+    const market = await client.readContract({
+      address: getAddress(morpho),
+      abi: morphoMarketAbi,
+      functionName: "market",
+      args: [marketId as `0x${string}`],
+      ...(blockNumber !== undefined ? { blockNumber } : {}),
+    });
+
+    const totalBorrowAssets = market[2];
+    const totalBorrowShares = market[3];
+    if (totalBorrowAssets <= 0n || totalBorrowShares <= 0n) return null;
+
+    return (BigInt(totalBorrowAssets) * ONE) / BigInt(totalBorrowShares);
+  } catch {
+    return null;
+  }
+}
+
+export async function getMorphoMarketHistoricalBorrowApy(
+  morpho: string,
+  marketId: string,
+  chainId: number,
+  windowSeconds: number,
+): Promise<bigint | null> {
+  if (windowSeconds <= 0) return null;
+
+  const bounds = await getHistoricalWindowBounds(chainId, windowSeconds);
+  if (!bounds) return null;
+
+  const [currentIndex, oldIndex] = await Promise.all([
+    getMorphoMarketBorrowIndex(morpho, marketId, chainId, bounds.latestBlockNumber),
+    getMorphoMarketBorrowIndex(morpho, marketId, chainId, bounds.oldBlockNumber),
+  ]);
+  if (currentIndex === null || oldIndex === null) return null;
+
+  return annualizeRawGrowth(currentIndex, oldIndex, bounds.elapsedSeconds);
+}
+
+export async function getAaveReserveHistoricalSupplyApy(
+  aToken: string,
+  chainId: number,
+  windowSeconds: number,
+): Promise<bigint | null> {
+  if (windowSeconds <= 0) return null;
+
+  const client = getViemClient(chainId);
+  if (!client) return null;
+
+  const context = await getAaveReserveContext(aToken, chainId);
+  if (!context) return null;
+
+  const bounds = await getHistoricalWindowBounds(chainId, windowSeconds);
+  if (!bounds) return null;
+
+  try {
+    const [currentIndex, oldIndex] = await Promise.all([
+      client.readContract({
+        address: getAddress(context.pool),
+        abi: aavePoolAbi,
+        functionName: "getReserveNormalizedIncome",
+        args: [getAddress(context.asset)],
+        blockNumber: bounds.latestBlockNumber,
+      }),
+      client.readContract({
+        address: getAddress(context.pool),
+        abi: aavePoolAbi,
+        functionName: "getReserveNormalizedIncome",
+        args: [getAddress(context.asset)],
+        blockNumber: bounds.oldBlockNumber,
+      }),
+    ]);
+    return annualizeRawGrowth(currentIndex, oldIndex, bounds.elapsedSeconds);
+  } catch {
+    return null;
+  }
+}
+
+export async function getAaveReserveHistoricalBorrowApy(
+  aToken: string,
+  chainId: number,
+  windowSeconds: number,
+): Promise<bigint | null> {
+  if (windowSeconds <= 0) return null;
+
+  const client = getViemClient(chainId);
+  if (!client) return null;
+
+  const context = await getAaveReserveContext(aToken, chainId);
+  if (!context) return null;
+
+  const bounds = await getHistoricalWindowBounds(chainId, windowSeconds);
+  if (!bounds) return null;
+
+  try {
+    const [currentIndex, oldIndex] = await Promise.all([
+      client.readContract({
+        address: getAddress(context.pool),
+        abi: aavePoolAbi,
+        functionName: "getReserveNormalizedVariableDebt",
+        args: [getAddress(context.asset)],
+        blockNumber: bounds.latestBlockNumber,
+      }),
+      client.readContract({
+        address: getAddress(context.pool),
+        abi: aavePoolAbi,
+        functionName: "getReserveNormalizedVariableDebt",
+        args: [getAddress(context.asset)],
+        blockNumber: bounds.oldBlockNumber,
+      }),
+    ]);
+    return annualizeRawGrowth(currentIndex, oldIndex, bounds.elapsedSeconds);
+  } catch {
+    return null;
+  }
+}
+
+export async function getAaveReserveCurrentSupplyApy(
+  aToken: string,
+  chainId: number,
+): Promise<bigint | null> {
+  const client = getViemClient(chainId);
+  if (!client) return null;
+
+  const context = await getAaveReserveContext(aToken, chainId);
+  if (!context) return null;
+
+  try {
+    const reserveData = await client.readContract({
+      address: getAddress(context.pool),
+      abi: aavePoolAbi,
+      functionName: "getReserveData",
+      args: [getAddress(context.asset)],
+    });
+    return rayAnnualRateToApyRaw(BigInt(reserveData[2]));
+  } catch {
+    return null;
+  }
+}
+
+export async function getAaveReserveCurrentBorrowApy(
+  aToken: string,
+  chainId: number,
+): Promise<bigint | null> {
+  const client = getViemClient(chainId);
+  if (!client) return null;
+
+  const context = await getAaveReserveContext(aToken, chainId);
+  if (!context) return null;
+
+  try {
+    const reserveData = await client.readContract({
+      address: getAddress(context.pool),
+      abi: aavePoolAbi,
+      functionName: "getReserveData",
+      args: [getAddress(context.asset)],
+    });
+    return rayAnnualRateToApyRaw(BigInt(reserveData[4]));
   } catch {
     return null;
   }
@@ -928,6 +1238,49 @@ async function findBlockAtOrBeforeTimestamp(
   return best;
 }
 
+async function getHistoricalWindowBounds(
+  chainId: number,
+  windowSeconds: number,
+): Promise<{
+  latestBlockNumber: bigint;
+  oldBlockNumber: bigint;
+  elapsedSeconds: number;
+} | null> {
+  if (windowSeconds <= 0) return null;
+
+  const client = getViemClient(chainId);
+  if (!client) return null;
+
+  let latestBlockNumber: bigint;
+  try {
+    latestBlockNumber = await client.getBlockNumber();
+  } catch {
+    return null;
+  }
+  if (latestBlockNumber <= 0n) return null;
+
+  const latestBlock = await getBlock(chainId, latestBlockNumber);
+  if (!latestBlock || latestBlock.timestamp <= 0n) return null;
+
+  const targetTs = latestBlock.timestamp - BigInt(windowSeconds);
+  if (targetTs <= 0n) return null;
+
+  const oldBlockNumber = await findBlockAtOrBeforeTimestamp(chainId, targetTs, latestBlockNumber);
+  if (oldBlockNumber === null) return null;
+
+  const oldBlock = await getBlock(chainId, oldBlockNumber);
+  if (!oldBlock) return null;
+
+  const elapsedSeconds = Number(latestBlock.timestamp - oldBlock.timestamp);
+  if (elapsedSeconds <= 0) return null;
+
+  return {
+    latestBlockNumber,
+    oldBlockNumber,
+    elapsedSeconds,
+  };
+}
+
 async function historicalConvertToAssetsAprForWindow(
   vault: string,
   chainId: number,
@@ -936,45 +1289,24 @@ async function historicalConvertToAssetsAprForWindow(
 ): Promise<bigint | null> {
   if (windowSeconds <= 0 || sharesRaw <= 0n) return null;
 
-  const client = getViemClient(chainId);
-  if (!client) return null;
+  const bounds = await getHistoricalWindowBounds(chainId, windowSeconds);
+  if (!bounds) return null;
 
-  let latestBlockNum: bigint;
-  try {
-    latestBlockNum = await client.getBlockNumber();
-  } catch {
-    return null;
-  }
-  if (latestBlockNum <= 0n) return null;
-
-  const latestBlockData = await getBlock(chainId, latestBlockNum);
-  if (!latestBlockData) return null;
-  const latestTs = latestBlockData.timestamp;
-  if (latestTs <= 0n) return null;
-
-  const targetTs = latestTs - BigInt(windowSeconds);
-  if (targetTs <= 0n) return null;
-
-  const oldBlockNum = await findBlockAtOrBeforeTimestamp(chainId, targetTs, latestBlockNum);
-  if (oldBlockNum === null) return null;
-
-  const oldBlockData = await getBlock(chainId, oldBlockNum);
-  if (!oldBlockData) return null;
-  const elapsed = Number(latestTs - oldBlockData.timestamp);
-  if (elapsed <= 0) return null;
-
-  const latestAssets = await getErc4626ConvertToAssets(vault, chainId, sharesRaw, latestBlockNum);
-  const oldAssets = await getErc4626ConvertToAssets(vault, chainId, sharesRaw, oldBlockNum);
+  const latestAssets = await getErc4626ConvertToAssets(
+    vault,
+    chainId,
+    sharesRaw,
+    bounds.latestBlockNumber,
+  );
+  const oldAssets = await getErc4626ConvertToAssets(
+    vault,
+    chainId,
+    sharesRaw,
+    bounds.oldBlockNumber,
+  );
   if (latestAssets === null || oldAssets === null || oldAssets <= 0n) return null;
 
-  try {
-    const growthRatio = Number(latestAssets) / Number(oldAssets);
-    if (growthRatio <= 0) return null;
-    const apy = Math.pow(growthRatio, SECONDS_PER_YEAR / elapsed) - 1.0;
-    return BigInt(Math.round(apy * Number(ONE)));
-  } catch {
-    return null;
-  }
+  return annualizeRawGrowth(latestAssets, oldAssets, bounds.elapsedSeconds);
 }
 
 export async function getHistoricalConvertToAssetsApr(
@@ -983,25 +1315,7 @@ export async function getHistoricalConvertToAssetsApr(
   windowSeconds: number,
   sharesRaw: bigint,
 ): Promise<bigint | null> {
-  if (windowSeconds <= 0 || sharesRaw <= 0n) return null;
-
-  const fallbackWindows = [
-    windowSeconds,
-    Math.min(windowSeconds, 86_400),
-    Math.min(windowSeconds, 21_600),
-    Math.min(windowSeconds, 3_600),
-    Math.min(windowSeconds, 900),
-  ];
-  const deduped: number[] = [];
-  for (const w of fallbackWindows) {
-    if (w > 0 && !deduped.includes(w)) deduped.push(w);
-  }
-
-  for (const w of deduped) {
-    const apr = await historicalConvertToAssetsAprForWindow(vault, chainId, w, sharesRaw);
-    if (apr !== null) return apr;
-  }
-  return null;
+  return historicalConvertToAssetsAprForWindow(vault, chainId, windowSeconds, sharesRaw);
 }
 
 export async function getOracleGrowthApr(

--- a/lib/onchain.ts
+++ b/lib/onchain.ts
@@ -1321,7 +1321,7 @@ export async function getHistoricalConvertToAssetsApr(
 export async function getOracleGrowthApr(
   oracleAddress: string,
   chainId: number,
-  windowSeconds: number = 7 * 24 * 60 * 60,
+  windowSeconds: number = 3 * 24 * 60 * 60,
 ): Promise<bigint | null> {
   const client = getViemClient(chainId);
   if (!client) return null;

--- a/lib/onchain.ts
+++ b/lib/onchain.ts
@@ -7,7 +7,11 @@ import {
   getAddress,
 } from "viem";
 import { mainnet, arbitrum, type Chain } from "viem/chains";
-import type { OnchainSourceConfig, ChainSourceConfig } from "./config";
+import {
+  DEFAULT_HISTORICAL_WINDOW_SECONDS,
+  type OnchainSourceConfig,
+  type ChainSourceConfig,
+} from "./config";
 
 export const ONE = 10n ** 18n;
 export const RAY = 10n ** 27n;
@@ -1321,7 +1325,7 @@ export async function getHistoricalConvertToAssetsApr(
 export async function getOracleGrowthApr(
   oracleAddress: string,
   chainId: number,
-  windowSeconds: number = 3 * 24 * 60 * 60,
+  windowSeconds: number = DEFAULT_HISTORICAL_WINDOW_SECONDS,
 ): Promise<bigint | null> {
   const client = getViemClient(chainId);
   if (!client) return null;

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,5 +1,5 @@
 import Redis from "ioredis";
-import type { VaultAprResult, AprComponent } from "./models";
+import type { VaultAprResult } from "./models";
 
 const CACHE_KEY = "yvusd:strategy_cache";
 const APR_RESULT_KEY = "yvusd:apr_result";
@@ -50,64 +50,4 @@ export async function readVaultAprs(addresses: string[]): Promise<(VaultAprResul
   const keys = addresses.map((a) => `${VAULT_APR_PREFIX}${a.toLowerCase()}`);
   const values = await getClient().mget(...keys);
   return values.map((raw) => (raw ? (JSON.parse(raw) as VaultAprResult) : null));
-}
-
-/* ── APR History (sorted sets for rolling average) ── */
-
-const APR_HISTORY_PREFIX = "yvusd:apr_history:";
-const DEFAULT_WINDOW_MS = 96 * 60 * 60 * 1000; // 96 hours
-
-const LOCKED_YVUSD = "0xaaafea48472f77563961cdb53291dedfb46f9040";
-
-/** Per-vault smoothing windows. Unlisted vaults use DEFAULT_WINDOW_MS. */
-const SMOOTHING_WINDOWS: Record<string, number> = {
-  [LOCKED_YVUSD]: 4 * 60 * 60 * 1000, // 4 hours
-};
-
-function getWindowMs(address: string): number {
-  const base = address.split(":")[0];
-  return SMOOTHING_WINDOWS[base.toLowerCase()] ?? DEFAULT_WINDOW_MS;
-}
-
-export async function pushAprSnapshot(address: string, apr: number, apy: number): Promise<void> {
-  const key = `${APR_HISTORY_PREFIX}${address.toLowerCase()}`;
-  const now = Date.now();
-  const windowMs = getWindowMs(address);
-  const value = JSON.stringify({ apr, apy, t: now });
-  const pipeline = getClient().pipeline();
-  pipeline.zadd(key, now, value);
-  pipeline.zremrangebyscore(key, 0, now - windowMs);
-  await pipeline.exec();
-}
-
-export async function enrichComponentsWithSmoothed(address: string, components: AprComponent[]): Promise<void> {
-  for (const component of components) {
-    const smoothed = await getSmoothedApr(`${address}:${component.label}`);
-    if (smoothed && smoothed.samples > 1) {
-      component.apr = smoothed.apr;
-      component.apy = smoothed.apy;
-    }
-  }
-}
-
-export async function getSmoothedApr(address: string): Promise<{ apr: number; apy: number; samples: number } | null> {
-  const key = `${APR_HISTORY_PREFIX}${address.toLowerCase()}`;
-  const now = Date.now();
-  const windowMs = getWindowMs(address);
-  const entries = await getClient().zrangebyscore(key, now - windowMs, now);
-  if (entries.length === 0) return null;
-
-  let aprSum = 0;
-  let apySum = 0;
-  for (const raw of entries) {
-    const entry = JSON.parse(raw) as { apr: number; apy: number; t: number };
-    aprSum += entry.apr;
-    apySum += entry.apy;
-  }
-
-  return {
-    apr: aprSum / entries.length,
-    apy: apySum / entries.length,
-    samples: entries.length,
-  };
 }

--- a/lib/strategy-store.ts
+++ b/lib/strategy-store.ts
@@ -49,7 +49,14 @@ interface VaultRef {
   symbol?: string;
 }
 
-const MORPHO_LOOPER_TYPES = new Set(["morpho-looper", "pt-morpho-looper"]);
+const LOOPER_TYPES = new Set([
+  "looper",
+  "morpho-looper",
+  "aave-looper",
+  "pt-looper",
+  "pt-morpho-looper",
+  "pt-aave-looper",
+]);
 
 function vaultKey(address: string, chainId: number): string {
   return `${chainId}:${address.toLowerCase()}`;
@@ -103,6 +110,9 @@ function buildHardcodedOffchainConfig(
         if (key in v) cfg[key] = v[key];
       }
       return cfg;
+    }
+    if (mode) {
+      return { ...v, type: mode };
     }
     return {};
   }
@@ -352,7 +362,7 @@ function discoverCollateralVaults(results: CacheData): VaultRef[] {
     for (const item of Object.values(entry.strategies ?? {})) {
       const meta = item.meta ?? {};
       const strategyType = String(meta.type ?? "").toLowerCase().replace(/_/g, "-");
-      if (!MORPHO_LOOPER_TYPES.has(strategyType)) continue;
+      if (!LOOPER_TYPES.has(strategyType)) continue;
 
       const collateral = meta.collateral as
         | { address?: string; name?: string }


### PR DESCRIPTION
## Summary

This PR removes output-level APR smoothing and replaces it with strategy-level historical inputs.

It also fixes `LockedYvUSD` so its `base_net_apr` is derived from the same headline `yvUSD net_apr` calculation path at calculation time, before results are stored.

## What Changed

- Removed Redis APR history smoothing and all read-time smoothing overrides.
- `/api/aprs`, `/api/aprs/[address]`, `/api/webhook`, and the local page now serve the stored APR results directly.
- Removed the `smooth` page mode.
- Fixed `LockedYvUSD` so `base_net_apr` uses the same headline net APR path as `yvUSD`, instead of publishing the wrong base rate.
- PT strategies now use trailing realized PT yield over `window_seconds` first, with implied/API fallback only when full historical data is unavailable.
- Looper strategies now use trailing realized collateral yield and trailing realized borrow cost instead of spot inputs.
- This applies across Morpho loopers, Aave loopers, PT loopers, and PT-Morpho/PT-Aave loopers.
- Added historical onchain helpers for Pendle PT realized yield, Morpho borrow index growth, and Aave supply/borrow index growth.
- Hardcoded offchain config handling and collateral discovery were expanded to support all looper variants.
- `window_seconds` is now the single strategy-level knob for these historical calculations.
- The shared default historical window is currently 2 days.

## Why

The old smoothing logic averaged the final published APR output. That hid the underlying strategy behavior and still allowed bad source inputs to leak through.

This PR moves the averaging to the strategy inputs instead:

- PTs use realized PT yield over a trailing window.
- Loopers use trailing realized collateral yield plus trailing realized borrow cost.
- Final vault APR stays a direct sum of strategy/component APRs.

That keeps the output honest while still damping noisy strategies.

## Behavior Notes

- No API schema changes.
- APR values will change because they are now derived from trailing strategy inputs instead of output smoothing.
- If the full historical window is unavailable, PT and looper paths fall back to the existing spot/implied source for that strategy.
- Old `yvusd:apr_history:*` keys are no longer read or written.

## Testing

- `./node_modules/.bin/tsc --noEmit`
