### PR TITLE
Stagger cron schedule before quarter hour marks

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "crons": [
     {
       "path": "/api/sync",
-      "schedule": "*/15 * * * *"
+      "schedule": "12,27,42,57 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Offsets the sync cron schedule by 3 minutes before each quarter hour (:12, :27, :42, :57) instead of running exactly on the marks (:00, :15, :30, :45)
- Ensures fresh data is propagated before downstream consumers check on the quarter hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)