### PR TITLE
Supply-chain hardening sweep

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,5 @@
+
+[install]
+minimumReleaseAge = 604800
+ignoreScripts = true
+exact = true

--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,6 @@
       "path": "/api/sync",
       "schedule": "12,27,42,57 * * * *"
     }
-  ]
+  ],
+  "installCommand": "bun install --frozen-lockfile"
 }


### PR DESCRIPTION
Automated hardening pass:

- PM configs touched: .bunfig.toml, .npmrc
- deps pinned from lockfile: 0
- deps range-stripped (fallback): 0
- workflow install lines frozen: 0
- workflow actions pinned to SHA: 0
