### PR TITLE
ci(deploy): source secrets from 1Password, inline at vercel build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,84 +1,35 @@
-name: Deploy to Vercel (production)
-
-# Secrets are the source-of-truth in 1Password, loaded here at build time and
-# inlined into the Vercel build output via next.config.ts. Nothing is stored in
-# Vercel's env dashboard.
-#
-# Required GitHub Actions secrets:
-#   OP_SERVICE_ACCOUNT_TOKEN  - 1Password service account token (read access to the vault below)
-#   VERCEL_TOKEN              - Vercel access token
-#   VERCEL_ORG_ID             - from `vercel link` / .vercel/project.json
-#   VERCEL_PROJECT_ID         - from `vercel link` / .vercel/project.json
-#
-# Expected 1Password item:
-#   vault: webops-prod   item: yvusd-apr-service
-#   fields: ETH_RPC_URL, ARB_RPC_URL, BASE_RPC_URL, KAT_RPC_URL, REDIS_URL,
-#           HYPERSYNC_API_TOKEN, KONG_WEBHOOK_SECRET, YVUSD_ADDRESS,
-#           LOCKED_YVUSD_ADDRESS, CRON_SECRET
-#
-# CRON_SECRET is the one exception to build-time inlining: Vercel's cron
-# scheduler signs the /api/sync request with it from Vercel's own env store, so
-# this workflow pushes it into that store (see the "Sync CRON_SECRET" step).
+name: Deploy to Vercel
 
 on:
+  pull_request:
   push:
     branches: [main]
 
 concurrency:
-  group: vercel-production
-  cancel-in-progress: false
+  group: vercel-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  deployments: write
+  pull-requests: write
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-
-      - name: Load secrets from 1Password
-        uses: 1password/load-secrets-action@v2
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          ETH_RPC_URL: op://webops-prod/yvusd-apr-service/ETH_RPC_URL
-          ARB_RPC_URL: op://webops-prod/yvusd-apr-service/ARB_RPC_URL
-          BASE_RPC_URL: op://webops-prod/yvusd-apr-service/BASE_RPC_URL
-          KAT_RPC_URL: op://webops-prod/yvusd-apr-service/KAT_RPC_URL
-          REDIS_URL: op://webops-prod/yvusd-apr-service/REDIS_URL
-          HYPERSYNC_API_TOKEN: op://webops-prod/yvusd-apr-service/HYPERSYNC_API_TOKEN
-          KONG_WEBHOOK_SECRET: op://webops-prod/yvusd-apr-service/KONG_WEBHOOK_SECRET
-          YVUSD_ADDRESS: op://webops-prod/yvusd-apr-service/YVUSD_ADDRESS
-          LOCKED_YVUSD_ADDRESS: op://webops-prod/yvusd-apr-service/LOCKED_YVUSD_ADDRESS
-          CRON_SECRET: op://webops-prod/yvusd-apr-service/CRON_SECRET
-
-      - name: Install Vercel CLI
-        run: npm install -g vercel@latest
-
-      - name: Pull Vercel project settings
-        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-
-      - name: Sync CRON_SECRET into Vercel env store
-        # Vercel's cron scheduler reads CRON_SECRET from its own store to sign
-        # the /api/sync request, so this one var can't be build-time inlined.
-        run: |
-          vercel env rm CRON_SECRET production --yes --token="$VERCEL_TOKEN" 2>/dev/null || true
-          printf '%s' "$CRON_SECRET" | vercel env add CRON_SECRET production --token="$VERCEL_TOKEN"
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build (inlines 1Password secrets into the output)
-        run: vercel build --prod --token="$VERCEL_TOKEN"
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy prebuilt output to production
-        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@711efc3dc97f65bbf6d6045d593732a935171e32
+    with:
+      vault: webops-prod-yvusd-apr-service
+      environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
+      secrets: |
+        ETH_RPC_URL=yvusd-apr-service/ETH_RPC_URL
+        ARB_RPC_URL=yvusd-apr-service/ARB_RPC_URL
+        BASE_RPC_URL=yvusd-apr-service/BASE_RPC_URL
+        KAT_RPC_URL=yvusd-apr-service/KAT_RPC_URL
+        REDIS_URL=yvusd-apr-service/REDIS_URL
+        HYPERSYNC_API_TOKEN=yvusd-apr-service/HYPERSYNC_API_TOKEN
+        KONG_WEBHOOK_SECRET=yvusd-apr-service/KONG_WEBHOOK_SECRET
+        YVUSD_ADDRESS=yvusd-apr-service/YVUSD_ADDRESS
+        LOCKED_YVUSD_ADDRESS=yvusd-apr-service/LOCKED_YVUSD_ADDRESS
+        CRON_SECRET=yvusd-apr-service/CRON_SECRET
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,84 @@
+name: Deploy to Vercel (production)
+
+# Secrets are the source-of-truth in 1Password, loaded here at build time and
+# inlined into the Vercel build output via next.config.ts. Nothing is stored in
+# Vercel's env dashboard.
+#
+# Required GitHub Actions secrets:
+#   OP_SERVICE_ACCOUNT_TOKEN  - 1Password service account token (read access to the vault below)
+#   VERCEL_TOKEN              - Vercel access token
+#   VERCEL_ORG_ID             - from `vercel link` / .vercel/project.json
+#   VERCEL_PROJECT_ID         - from `vercel link` / .vercel/project.json
+#
+# Expected 1Password item:
+#   vault: webops-prod   item: yvusd-apr-service
+#   fields: ETH_RPC_URL, ARB_RPC_URL, BASE_RPC_URL, KAT_RPC_URL, REDIS_URL,
+#           HYPERSYNC_API_TOKEN, KONG_WEBHOOK_SECRET, YVUSD_ADDRESS,
+#           LOCKED_YVUSD_ADDRESS, CRON_SECRET
+#
+# CRON_SECRET is the one exception to build-time inlining: Vercel's cron
+# scheduler signs the /api/sync request with it from Vercel's own env store, so
+# this workflow pushes it into that store (see the "Sync CRON_SECRET" step).
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: vercel-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ETH_RPC_URL: op://webops-prod/yvusd-apr-service/ETH_RPC_URL
+          ARB_RPC_URL: op://webops-prod/yvusd-apr-service/ARB_RPC_URL
+          BASE_RPC_URL: op://webops-prod/yvusd-apr-service/BASE_RPC_URL
+          KAT_RPC_URL: op://webops-prod/yvusd-apr-service/KAT_RPC_URL
+          REDIS_URL: op://webops-prod/yvusd-apr-service/REDIS_URL
+          HYPERSYNC_API_TOKEN: op://webops-prod/yvusd-apr-service/HYPERSYNC_API_TOKEN
+          KONG_WEBHOOK_SECRET: op://webops-prod/yvusd-apr-service/KONG_WEBHOOK_SECRET
+          YVUSD_ADDRESS: op://webops-prod/yvusd-apr-service/YVUSD_ADDRESS
+          LOCKED_YVUSD_ADDRESS: op://webops-prod/yvusd-apr-service/LOCKED_YVUSD_ADDRESS
+          CRON_SECRET: op://webops-prod/yvusd-apr-service/CRON_SECRET
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Pull Vercel project settings
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Sync CRON_SECRET into Vercel env store
+        # Vercel's cron scheduler reads CRON_SECRET from its own store to sign
+        # the /api/sync request, so this one var can't be build-time inlined.
+        run: |
+          vercel env rm CRON_SECRET production --yes --token="$VERCEL_TOKEN" 2>/dev/null || true
+          printf '%s' "$CRON_SECRET" | vercel env add CRON_SECRET production --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build (inlines 1Password secrets into the output)
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy prebuilt output to production
+        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,5 @@ jobs:
         KONG_WEBHOOK_SECRET=yvusd-apr-service/KONG_WEBHOOK_SECRET
         YVUSD_ADDRESS=yvusd-apr-service/YVUSD_ADDRESS
         LOCKED_YVUSD_ADDRESS=yvusd-apr-service/LOCKED_YVUSD_ADDRESS
-        CRON_SECRET=yvusd-apr-service/CRON_SECRET
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ A running Redis instance is required. To run redis on localhost, try docker like
 docker run --rm -p 6379:6379 redis:latest
 ```
 
-### `CRON_SECRET`
+### `CRON_SECRET` (Vercel dashboard only)
 
-Vercel cron jobs call `GET /api/sync` every 15 minutes. The endpoint requires a `CRON_SECRET` environment variable to authenticate these requests. Vercel sends the secret automatically as an `Authorization: Bearer <secret>` header.
+Vercel cron jobs call `GET /api/sync` every 15 minutes. The endpoint requires `CRON_SECRET` to authenticate these requests. Vercel sends it automatically as an `Authorization: Bearer <secret>` header.
+
+**This is the only secret that lives in Vercel's env store.** All other runtime secrets (RPC URLs, Redis, Hypersync, Kong, addresses) are loaded from 1Password at build time and inlined into the deployment — they are not stored on Vercel. `CRON_SECRET` cannot follow that path: Vercel's cron scheduler signs requests from the project env store, and the deploy workflow does not push it into Vercel. Do not delete it when cleaning the dashboard after the 1Password migration.
 
 Generate a secret (at least 16 random characters):
 
@@ -44,7 +46,7 @@ Add it as an environment variable in your Vercel project:
 2. Add `CRON_SECRET` with your generated value
 3. Scope it to **Production** (cron jobs only run on production deployments)
 
-When `CRON_SECRET` is not set (e.g. local dev), the auth check is skipped so you can call the endpoint freely.
+In production, if `CRON_SECRET` is unset the route returns `500` (fail closed). In local dev (`NODE_ENV !== "production"`), the auth check is skipped so you can call the endpoint freely.
 
 ## Running
 
@@ -79,7 +81,7 @@ Possible `status` values: `ok`, `degraded` (stale data or empty), `error` (Redis
 
 Triggers a full sync cycle: indexes strategy events from the chain, hydrates onchain metadata, computes APRs for all configured vaults, and writes results to Redis. Called automatically by Vercel cron every 15 minutes.
 
-In production, requires `Authorization: Bearer <CRON_SECRET>` header (Vercel sends this automatically). In dev, the auth check is skipped when `CRON_SECRET` is not set.
+Requires `Authorization: Bearer <CRON_SECRET>` (Vercel cron sends this automatically). Production fails closed with `500` if `CRON_SECRET` is unset; local dev skips auth when it is absent. See [CRON_SECRET](#cron_secret-vercel-dashboard-only).
 
 **Response**
 

--- a/app/api/sync/route.ts
+++ b/app/api/sync/route.ts
@@ -45,7 +45,16 @@ async function sync(reset: boolean = false) {
 
 export async function GET(request: NextRequest) {
   const secret = process.env.CRON_SECRET;
-  if (secret) {
+  if (!secret) {
+    // Fail closed in production so wiping the Vercel env store cannot leave
+    // /api/sync (including ?reset=true) publicly callable. Local dev skips auth.
+    if (process.env.NODE_ENV === "production") {
+      return NextResponse.json(
+        { error: "CRON_SECRET not configured" },
+        { status: 500 },
+      );
+    }
+  } else {
     const authHeader = request.headers.get("authorization");
     if (authHeader !== `Bearer ${secret}`) {
       return new Response("Unauthorized", { status: 401 });

--- a/lib/onchain.ts
+++ b/lib/onchain.ts
@@ -236,12 +236,23 @@ export function initOnchainClients(config: OnchainSourceConfig): void {
   _sourceConfig = config;
 }
 
+// Static map of the rpc_url_env names used in config/config.yaml. Literal
+// process.env.* access is required so next.config.ts can inline the 1Password
+// values at build time — dynamic process.env[name] access is NOT inlined and
+// would resolve to undefined on Vercel (build-time env isn't carried to runtime).
+const RPC_URL_ENV: Record<string, string | undefined> = {
+  ETH_RPC_URL: process.env.ETH_RPC_URL,
+  ARB_RPC_URL: process.env.ARB_RPC_URL,
+  BASE_RPC_URL: process.env.BASE_RPC_URL,
+  KAT_RPC_URL: process.env.KAT_RPC_URL,
+};
+
 function resolveRpcUrl(
   chainConfig?: { rpc_url_env?: string; rpc_url?: string },
 ): string | undefined {
   if (!chainConfig) return undefined;
   if (chainConfig.rpc_url) return chainConfig.rpc_url;
-  if (chainConfig.rpc_url_env) return process.env[chainConfig.rpc_url_env] || undefined;
+  if (chainConfig.rpc_url_env) return RPC_URL_ENV[chainConfig.rpc_url_env] || undefined;
   return undefined;
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,13 @@
 import type { NextConfig } from "next";
 
-// Runtime config sourced from 1Password and injected at `vercel build` time
-// (see .github/workflows/deploy.yml). Listed vars are inlined into the build
-// output so nothing has to live in Vercel's env store. All are referenced
-// server-side only, so they never reach the client bundle.
+// Runtime config sourced from 1Password via yearn-gha vercel-deploy and
+// injected at `vercel build` time (see .github/workflows/deploy.yml). Listed
+// vars are inlined into the build output so nothing has to live in Vercel's
+// env store. All are referenced server-side only, so they never reach the
+// client bundle.
 // Note: CRON_SECRET is intentionally NOT here — Vercel's cron scheduler signs
-// requests from its own env store, so deploy.yml pushes it into Vercel instead.
+// requests from its own env store, so CRON_SECRET must remain set on the
+// Vercel project (not only as a build-env).
 const INLINED_ENV = [
   "ETH_RPC_URL",
   "ARB_RPC_URL",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,31 @@
 import type { NextConfig } from "next";
 
+// Runtime config sourced from 1Password and injected at `vercel build` time
+// (see .github/workflows/deploy.yml). Listed vars are inlined into the build
+// output so nothing has to live in Vercel's env store. All are referenced
+// server-side only, so they never reach the client bundle.
+// Note: CRON_SECRET is intentionally NOT here — Vercel's cron scheduler signs
+// requests from its own env store, so deploy.yml pushes it into Vercel instead.
+const INLINED_ENV = [
+  "ETH_RPC_URL",
+  "ARB_RPC_URL",
+  "BASE_RPC_URL",
+  "KAT_RPC_URL",
+  "REDIS_URL",
+  "HYPERSYNC_API_TOKEN",
+  "KONG_WEBHOOK_SECRET",
+  "YVUSD_ADDRESS",
+  "LOCKED_YVUSD_ADDRESS",
+] as const;
+
+// Only inline vars that are actually set, so code-level `|| default` fallbacks
+// still apply when a var is absent (e.g. local dev).
+const env = Object.fromEntries(
+  INLINED_ENV.flatMap((k) => (process.env[k] ? [[k, process.env[k]!]] : [])),
+);
+
 const nextConfig: NextConfig = {
+  env,
   serverExternalPackages: ["@envio-dev/hypersync-client", "ioredis"],
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,9 +5,9 @@ import type { NextConfig } from "next";
 // vars are inlined into the build output so nothing has to live in Vercel's
 // env store. All are referenced server-side only, so they never reach the
 // client bundle.
-// Note: CRON_SECRET is intentionally NOT here — Vercel's cron scheduler signs
-// requests from its own env store, so CRON_SECRET must remain set on the
-// Vercel project (not only as a build-env).
+// CRON_SECRET is intentionally NOT inlined. Vercel cron signs /api/sync from
+// the project env store, so CRON_SECRET must stay set in the Vercel dashboard
+// (the one exception to "nothing secret in Vercel"). See README.
 const INLINED_ENV = [
   "ETH_RPC_URL",
   "ARB_RPC_URL",

--- a/vercel.json
+++ b/vercel.json
@@ -6,5 +6,8 @@
       "schedule": "12,27,42,57 * * * *"
     }
   ],
-  "installCommand": "bun install --frozen-lockfile"
+  "installCommand": "bun install --frozen-lockfile",
+  "github": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
## Summary

Moves this service onto the 1Password → GitHub Actions → Vercel deploy flow. A thin caller workflow invokes the reusable `yearn/yearn-gha` `vercel-deploy.yml` (pinned to commit SHA `711efc3`). Secrets load from the `webops-prod-yvusd-apr-service` vault and are inlined into the build output via `next.config.ts` `env`, so the Vercel env store stays empty for app secrets and 1Password remains the single source of truth (with one documented exception: `CRON_SECRET`).

## Changes

- **`.github/workflows/deploy.yml`** — thin caller of `yearn/yearn-gha` `vercel-deploy.yml@711efc3`. Vault: `webops-prod-yvusd-apr-service`. Only GH secret required: `OP_SERVICE_ACCOUNT_TOKEN` (`VERCEL_TOKEN` / `VERCEL_ORG_ID` from `webops-prod-shared`, `VERCEL_PROJECT_ID` from the project vault). Preview on PRs, production on `main`. Concurrency-guarded per ref.
- **`next.config.ts`** — inline a fixed allowlist of server-side env vars (RPC URLs, Redis, Hypersync token, Kong secret, addresses) into the build output. Only vars that are set get inlined, so code-level `|| default` fallbacks still apply in local dev. `CRON_SECRET` is intentionally not inlined.
- **`lib/onchain.ts`** — replace dynamic `process.env[name]` RPC lookup with a static `RPC_URL_ENV` map. Literal `process.env.*` access is required for Next to inline the values; dynamic access resolves to `undefined` at runtime.
- **`vercel.json`** — disable Vercel Git integration (`github.enabled: false`); deploys go through GHA only.
- **`CRON_SECRET`** — stays in the Vercel project env store (dashboard). Vercel cron signs `/api/sync` from that store; the reusable workflow does not push it. `/api/sync` fails closed with `500` in production when unset; local dev still skips auth.

## Ops note

When cleaning the Vercel env dashboard after this migration, **keep `CRON_SECRET`**. It is the only secret that must remain there. See README section "CRON_SECRET (Vercel dashboard only)".

## Testing

- [x] GHA preview deploy from this PR is healthy: `/api/health` reports Redis ok; `/api/aprs` returns 200
- [x] Unauthenticated `/api/sync` on the preview returns 401 (CRON_SECRET still set in Vercel dashboard)
- [ ] After merge: confirm production deploy from `main` and that cron continues to hit `/api/sync` successfully