### PR TITLE
ci: migrate Vercel deploy to Doppler OIDC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,26 +13,11 @@ permissions:
   contents: read
   deployments: write
   pull-requests: write
+  id-token: write
 
 jobs:
   deploy:
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@711efc3dc97f65bbf6d6045d593732a935171e32
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@9701cd661a98fda358bb7b273b2baab97f12dea2
     with:
-      vault: webops-prod-yvusd-apr-service
-      environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
-      secrets: |
-        ETH_RPC_URL=yvusd-apr-service/ETH_RPC_URL
-        ARB_RPC_URL=yvusd-apr-service/ARB_RPC_URL
-        BASE_RPC_URL=yvusd-apr-service/BASE_RPC_URL
-        KAT_RPC_URL=yvusd-apr-service/KAT_RPC_URL
-        REDIS_URL=yvusd-apr-service/REDIS_URL
-        HYPERSYNC_API_TOKEN=yvusd-apr-service/HYPERSYNC_API_TOKEN
-        KONG_WEBHOOK_SECRET=yvusd-apr-service/KONG_WEBHOOK_SECRET
-        YVUSD_ADDRESS=yvusd-apr-service/YVUSD_ADDRESS
-        LOCKED_YVUSD_ADDRESS=yvusd-apr-service/LOCKED_YVUSD_ADDRESS
-        OTEL_EXPORTER_OTLP_ENDPOINT=yvusd-apr-service/OTEL_EXPORTER_OTLP_ENDPOINT
-        OTEL_EXPORTER_OTLP_HEADERS=yvusd-apr-service/OTEL_EXPORTER_OTLP_HEADERS
-        OTEL_SERVICE_NAME=yvusd-apr-service/OTEL_SERVICE_NAME
-        OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=yvusd-apr-service/OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      project: yvusd-apr-service
+      identity-id: ${{ github.event_name == 'pull_request' && vars.DOPPLER_PREVIEW_IDENTITY_ID || vars.DOPPLER_PRODUCTION_IDENTITY_ID }}

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Possible `status` values: `ok`, `degraded` (stale data or empty), `error` (Redis
 
 Triggers a full sync cycle: indexes strategy events from the chain, hydrates onchain metadata, computes APRs for all configured vaults, and writes results to Redis. Called automatically by Vercel cron every 15 minutes.
 
-Requires `Authorization: Bearer <CRON_SECRET>` (Vercel cron sends this automatically). Production fails closed with `500` if `CRON_SECRET` is unset; local dev skips auth when it is absent. See [CRON_SECRET](#cron_secret-vercel-dashboard-only).
+Requires `Authorization: Bearer <CRON_SECRET>` (Vercel cron sends this automatically). Production fails closed with `500` if `CRON_SECRET` is unset; local dev skips auth when it is absent. See [CRON_SECRET](#cron_secret).
 
 **Response**
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ A running Redis instance is required. To run redis on localhost, try docker like
 docker run --rm -p 6379:6379 redis:latest
 ```
 
-### `CRON_SECRET` (Vercel dashboard only)
+### `CRON_SECRET`
 
 Vercel cron jobs call `GET /api/sync` every 15 minutes. The endpoint requires `CRON_SECRET` to authenticate these requests. Vercel sends it automatically as an `Authorization: Bearer <secret>` header.
 
-**This is the only secret that lives in Vercel's env store.** All other runtime secrets (RPC URLs, Redis, Hypersync, Kong, addresses) are loaded from 1Password at build time and inlined into the deployment — they are not stored on Vercel. `CRON_SECRET` cannot follow that path: Vercel's cron scheduler signs requests from the project env store, and the deploy workflow does not push it into Vercel. Do not delete it when cleaning the dashboard after the 1Password migration.
+Store `CRON_SECRET` in both Doppler configs (`prd` and `preview`) so the Vercel integration keeps it in the project env store after a sync. Vercel cron signs requests from that store; do not leave it only as an unmanaged Vercel variable.
+
+All other runtime secrets (RPC URLs, Redis, Hypersync, Kong, OTEL, addresses) also live in Doppler `prd`/`preview`. The deploy workflow no longer inlines them from 1Password.
 
 Generate a secret (at least 16 random characters):
 
@@ -40,11 +42,12 @@ Generate a secret (at least 16 random characters):
 openssl rand -base64 32
 ```
 
-Add it as an environment variable in your Vercel project:
+Add it in Doppler `prd` and `preview` (the Vercel integration copies it into the project env store):
 
-1. Go to **Settings > Environment Variables** in the Vercel dashboard
-2. Add `CRON_SECRET` with your generated value
-3. Scope it to **Production** (cron jobs only run on production deployments)
+```
+doppler secrets set CRON_SECRET --project yvusd-apr-service --config prd
+doppler secrets set CRON_SECRET --project yvusd-apr-service --config preview
+```
 
 In production, if `CRON_SECRET` is unset the route returns `500` (fail closed). In local dev (`NODE_ENV !== "production"`), the auth check is skipped so you can call the endpoint freely.
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,13 +1,12 @@
 import type { NextConfig } from "next";
 
-// Runtime config sourced from 1Password via yearn-gha vercel-deploy and
-// injected at `vercel build` time (see .github/workflows/deploy.yml). Listed
-// vars are inlined into the build output so nothing has to live in Vercel's
-// env store. All are referenced server-side only, so they never reach the
-// client bundle.
+// Runtime config sourced from Doppler `prd`/`preview` via the Vercel
+// integration (see .github/workflows/deploy.yml). Listed vars are inlined
+// into the build output so they are present at runtime. All are referenced
+// server-side only, so they never reach the client bundle.
 // CRON_SECRET is intentionally NOT inlined. Vercel cron signs /api/sync from
-// the project env store, so CRON_SECRET must stay set in the Vercel dashboard
-// (the one exception to "nothing secret in Vercel"). See README.
+// the project env store. Keep it in both Doppler configs so the Vercel sync
+// cannot drop it. See README.
 const INLINED_ENV = [
   "ETH_RPC_URL",
   "ARB_RPC_URL",


### PR DESCRIPTION
Replaces the 1Password/Infisical-era deploy caller with the Doppler OIDC shape from yearn/yearn-gha.

- Pins `vercel-deploy.yml` to `9701cd661a98fda358bb7b273b2baab97f12dea2` (same SHA as katana-apr-service).
- Passes `project: yvusd-apr-service` and event-matched `identity-id` from `DOPPLER_PREVIEW_IDENTITY_ID` / `DOPPLER_PRODUCTION_IDENTITY_ID` repo vars (already set).
- Adds `id-token: write`; drops the per-secret list and `OP_SERVICE_ACCOUNT_TOKEN` — app secrets now reach Vercel via Doppler syncs (`preview` → Preview, `prd` → Production), not the runner.

Doppler side is provisioned: project configs, OIDC identities bound to the pinned SHA, service account restricted to `deploy-configs`, Vercel syncs created.

After first successful deploy from this workflow, disconnect the Vercel Git integration to avoid double deploys.